### PR TITLE
feat: add GetTransientState, SetTransientState for eip-1153 (transient storage)

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1054,3 +1054,11 @@ func (s *StateDB) AddressInAccessList(addr common.Address) bool {
 func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
 	return s.accessList.Contains(addr, slot)
 }
+
+func (s *StateDB) GetTransientState(addr common.Address, key common.Hash) common.Hash {
+	panic("not implemented")
+}
+
+func (s *StateDB) SetTransientState(addr common.Address, key, value common.Hash) {
+	panic("not implemented")
+}


### PR DESCRIPTION
The goal is support opcodes(TSTORE, TLOAD, MCOPY, BLOBHASH, BLOBBASEFEE) included in geth v1.13.14.
In the case about `Transient Storage (TSTORE, TLOAD)`, it needs to add two methods, `GetTransientState` and `SetTransientState`.
In the cosmos-evm context, the statedb logic is implemented in the x/vm module.
So the 2 methods added in this pr just cause `panic`.